### PR TITLE
Fix README import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 As the name suggests, this a super simple plugin that makes a website function as a Single Page Application.
 
 ## How to use
-Simply import `super-simples-spa.js` as a module in all your pages, create a new instance of it and run the `init` method:
+Simply import `super-simple-spa.js` as a module in all your pages, create a new instance of it and run the `init` method:
 
 ```js
 import SuperSimpleSPA from './super-simple-spa.js';


### PR DESCRIPTION
## Summary
- correct `super-simple-spa.js` import path in README

## Testing
- `node --check --input-type=module` on README example snippet
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840e5c050348326bab5dfcbf21263a3